### PR TITLE
Fixing rke2-etcd metrics collection

### DIFF
--- a/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
+++ b/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh
@@ -987,11 +987,9 @@ rke2-etcd() {
         ${RKE2_DATA_DIR}/bin/crictl exec ${RKE2_ETCD} etcdctl --cert ${ETCD_CERT} --key ${ETCD_KEY} --cacert ${ETCD_CACERT} --endpoints=$ETCDCTL_ENDPOINTS alarm list > $TMPDIR/etcd/alarmlist 2>&1
 
         techo "Collecting rke2 etcd metrics"
-        ETCD_ENDPOINTS=$(grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}:2379\b' $TMPDIR/etcd/memberlist | uniq)
-        for ENDPOINT in ${ETCD_ENDPOINTS}
-          do
-            curl -sL --connect-timeout 5 --cacert ${ETCD_CACERT} --key ${ETCD_KEY} --cert ${ETCD_CERT} https://$ENDPOINT/metrics > $TMPDIR/etcd/etcd-metrics-$ENDPOINT.txt
-        done
+        ETCD_ENDPOINTS=$(cat /var/lib/rancher/rke2/server/db/etcd/config|grep listen-metrics-urls:|awk '{print $2}')
+        curl $ETCD_ENDPOINTS/metrics > $TMPDIR/etcd/etcd-metrics-$ENDPOINT.txt
+       
       fi
     else
       techo "[!] Containerd is offline, skipping etcd collection"


### PR DESCRIPTION
This part of the code is not working, 
        techo "Collecting rke2 etcd metrics"
        ETCD_ENDPOINTS=$(grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}:2379\b' $TMPDIR/etcd/memberlist | uniq)
        for ENDPOINT in ${ETCD_ENDPOINTS}
          do
            curl -sL --connect-timeout 5 --cacert ${ETCD_CACERT} --key ${ETCD_KEY} --cert ${ETCD_CERT} https://$ENDPOINT/metrics > $TMPDIR/etcd/etcd-metrics-$ENDPOINT.txt
        done
The metrics by default are published on line listen-metrics-urls: in file /var/lib/rancher/rke2/server/db/etcd/config